### PR TITLE
Deprecate constants used in object-cache drop-in

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -85,8 +85,7 @@ function wp_cache_delete( $key, $group = '', $time = 0 ) {
 }
 
 /**
- * Invalidate all items in the cache. If `WP_REDIS_SELECTIVE_FLUSH` is `true`,
- * only keys prefixed with the `WP_CACHE_KEY_SALT` are flushed.
+ * Invalidate all items in the cache.
  *
  * @param int $delay Number of seconds to wait before invalidating the items.
  *
@@ -659,8 +658,7 @@ class WP_Object_Cache {
     }
 
     /**
-     * Invalidate all items in the cache. If `WP_REDIS_SELECTIVE_FLUSH` is `true`,
-     * only keys prefixed with the `WP_CACHE_KEY_SALT` are flushed.
+     * Invalidate all items in the cache.
      *
      * @param int $delay Number of seconds to wait before invalidating the items.
      *

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -678,7 +678,7 @@ class WP_Object_Cache {
 
         if ( $this->redis_status() ) {
             $salt      = defined( 'WP_CACHE_KEY_SALT' ) ? trim( WP_CACHE_KEY_SALT ) : null;
-            $selective = defined( 'WP_REDIS_SELECTIVE_FLUSH' ) ? WP_REDIS_SELECTIVE_FLUSH : null;
+            $selective = true; // @deprecated WP_REDIS_SELECTIVE_FLUSH
 
             if ( $salt && $selective ) {
                 $script = "

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -677,7 +677,7 @@ class WP_Object_Cache {
         $this->cache = array();
 
         if ( $this->redis_status() ) {
-            $salt      = defined( 'WP_CACHE_KEY_SALT' ) ? trim( WP_CACHE_KEY_SALT ) : null;
+            $salt      = $this->get_cache_key_salt();
             $selective = true; // @deprecated WP_REDIS_SELECTIVE_FLUSH
 
             if ( $salt && $selective ) {
@@ -1055,7 +1055,7 @@ class WP_Object_Cache {
             $group = 'default';
         }
 
-        $salt   = defined( 'WP_CACHE_KEY_SALT' ) ? trim( WP_CACHE_KEY_SALT ) : '';
+        $salt   = $this->get_cache_key_salt();
         $prefix = in_array( $group, $this->global_groups ) ? $this->global_prefix : $this->blog_prefix;
 
         return "{$salt}{$prefix}:{$group}:{$key}";
@@ -1334,6 +1334,26 @@ class WP_Object_Cache {
 
         error_log( $exception );
     }
+
+	/**
+     * Get the cache key salt
+     *
+	 * @return string|null
+	 */
+	private function get_cache_key_salt() {
+		if ( defined( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
+			return SPINUPWP_CACHE_KEY_SALT;
+		}
+		if ( getenv( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
+			return getenv( 'SPINUPWP_CACHE_KEY_SALT' );
+		}
+		if ( defined( 'WP_CACHE_KEY_SALT' ) ) {
+		    // @deprecated
+			return WP_CACHE_KEY_SALT;
+		}
+
+		return null;
+	}
 }
 
 endif;


### PR DESCRIPTION
This removes the use of `WP_REDIS_SELECTIVE_FLUSH` and replaces `WP_CACHE_KEY_SALT` with `SPINUPWP_CACHE_KEY_SALT` that can be defined as an env var or constant.