### PR TITLE
whitelabel admin bar name for spinupwp sites

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Create a new team account, invite a member of your team, and allow them to spin 
 
 = 1.2 (2020-08-17) =
 * Added support for WP 5.5 `wp_cache_get_multi()` function.
+* Changed Admin Bar menu title from "SpinupWP" to "Cache"
 
 = 1.1.2 (2019-07-26) =
 * Only purge the page cache when a public post type is updated.

--- a/src/AdminBar.php
+++ b/src/AdminBar.php
@@ -32,7 +32,7 @@ class AdminBar {
 
 		$wp_admin_bar->add_node( array(
 			'id'    => 'spinupwp',
-			'title' => (getenv('SPINUPWP_SITE')) ? 'Cache' : 'SpinupWP',
+			'title' => apply_filters( 'spinupwp_admin_bar_title', 'Cache' ),
 		) );
 
 		foreach ( $this->items as $item ) {

--- a/src/AdminBar.php
+++ b/src/AdminBar.php
@@ -32,7 +32,7 @@ class AdminBar {
 
 		$wp_admin_bar->add_node( array(
 			'id'    => 'spinupwp',
-			'title' => 'SpinupWP',
+			'title' => (getenv('SPINUPWP_SITE')) ? 'Cache' : 'SpinupWP',
 		) );
 
 		foreach ( $this->items as $item ) {

--- a/src/AdminBar.php
+++ b/src/AdminBar.php
@@ -32,7 +32,7 @@ class AdminBar {
 
 		$wp_admin_bar->add_node( array(
 			'id'    => 'spinupwp',
-			'title' => apply_filters( 'spinupwp_admin_bar_title', 'Cache' ),
+			'title' => apply_filters( 'spinupwp_admin_bar_title', __( 'Cache' ) ),
 		) );
 
 		foreach ( $this->items as $item ) {


### PR DESCRIPTION
I'm not as familiar with WP plugin development. I managed to get this setup locally and get the env vars set to show the admin bar, etc.

This should show "Cache" in the admin bar instead of "SpinupWP" for any sites installed on our Spinup servers.

Updates to resolve deliciousbrains/spinupwp/issues/1307

Let me know if I need to do anything else or there's a different procedure for updates like this.