### PR TITLE
Make sure the Cache admin menu bar item is visible on small screens

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,6 +1,33 @@
+#wpadminbar #wp-admin-bar-spinupwp > .ab-item::before {
+	content: "\f226";
+	top: 2px;
+}
+
 @media screen and (max-width: 782px) {
 	#wpadminbar #wp-admin-bar-spinupwp {
 		display: block;
 		position: static;
+	}
+
+	#wpadminbar #wp-admin-bar-spinupwp > .ab-item {
+		text-indent: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		width: 52px;
+		padding: 0;
+		color: #a0a5aa;
+		position: relative;
+	}
+
+	#wpadminbar #wp-admin-bar-spinupwp > .ab-item::before {
+		display: block;
+		text-indent: 0;
+		font: normal 32px/1 dashicons;
+		speak: never;
+		top: 7px;
+		width: 52px;
+		text-align: center;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 	}
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,6 @@
+@media screen and (max-width: 782px) {
+	#wpadminbar #wp-admin-bar-spinupwp {
+		display: block;
+		position: static;
+	}
+}

--- a/src/AdminBar.php
+++ b/src/AdminBar.php
@@ -10,10 +10,32 @@ class AdminBar {
 	private $items = array();
 
 	/**
+	 * @var string
+	 */
+	public $url;
+
+	/**
+	 * AdminBar constructor.
+	 *
+	 * @param string $url
+	 */
+	public function __construct( $url ) {
+		$this->url = $url;
+	}
+
+	/**
 	 * Init
 	 */
 	public function init() {
 		add_action( 'admin_bar_menu', array( $this, 'render' ), 100 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Enqueue admin scripts.
+	 */
+	public function enqueue_scripts() {
+		wp_enqueue_style( 'spinupwp-admin', $this->url . 'assets/css/admin.css', array(), '1.0' );
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,7 +30,7 @@ class Plugin {
 	 * Run the SpinupWP plugin.
 	 */
 	public function run() {
-		$admin_bar     = new AdminBar;
+		$admin_bar     = new AdminBar( $this->url );
 		$admin_notices = new AdminNotices( $this->url );
 		$cli           = new Cli;
 


### PR DESCRIPTION
Resolves https://github.com/deliciousbrains/spinupwp-plugin/issues/29

![image](https://user-images.githubusercontent.com/1770201/100727403-17247480-33be-11eb-85df-7a6783344560.png)
