### PR TITLE
Removed object-cache.php drop-in

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,9 @@ Create a new team account, invite a member of your team, and allow them to spin 
 
 == Changelog ==
 
+= 1.4 (2021-09-28) =
+* Removed object-cache.php drop-in in favor of default from Redis Object Cache plugin.
+
 = 1.3 (2021-01-06) =
 * Added compatibility with Elementor Website Builder.
 * Show the "Cache" Admin Bar menu item on mobile devices.
@@ -102,7 +105,7 @@ Create a new team account, invite a member of your team, and allow them to spin 
 * Fix object-cache.php file deletion on Redis Object Cache plugin uninstall.
 
 = 1.1 (2019-07-09) =
-* `wp spinupwp status` and `wp spinupwp update-object-cache-dropin` WP-CLI commands added.
+* `wp spinupwp status` WP-CLI command added.
 * WP-CLI cache related commands moved to new `cache` subcommand, e.g. `wp spinupwp cache purge-site`.
 * Don't report "Your site is set to log errors to a potentially public file" issue in site health tool.
 * Automatically update object-cache.php drop-in when a new version is available.

--- a/src/AdminNotices.php
+++ b/src/AdminNotices.php
@@ -79,14 +79,14 @@ class AdminNotices {
 	}
 
 	/**
-	 * Show a notice about Redis Object Cache plugin being disabled.
+	 * Show a notice about Redis Object Cache plugin being needed.
 	 */
 	public function show_redis_cache_disabled_notice() {
 		if ( ! current_user_can( 'manage_options' ) || ! get_site_option( 'spinupwp_redis_cache_disabled' ) || get_site_option( 'spinupwp_redis_cache_disabled_notice_dismissed' ) ) {
 			return;
 		}
 
-		$msg   = __( 'The Redis Object Cache plugin has been deactivated and can be removed. The SpinupWP plugin now handles clearing the Redis object cache.', 'spinupwp' );
+		$msg   = __( 'Please update to the latest version of the SpinupWP plugin, then install <a target="_blank" href="https://wordpress.org/plugins/redis-cache/">Redis Object Cache</a>. The Redis Object Cache plugin will now handle clearing the Redis object cache.', 'spinupwp' );
 		$nonce = wp_create_nonce( 'dismiss-notice' );
 		echo "<div class=\"spinupwp notice notice-success is-dismissible\" data-nonce=\"{$nonce}\" data-notice=\"redis_cache_disabled\"><p><strong>SpinupWP</strong> — {$msg}</p></div>";
 	}

--- a/src/AdminNotices.php
+++ b/src/AdminNotices.php
@@ -62,7 +62,6 @@ class AdminNotices {
 	public function show_notices() {
 		$this->show_mail_notice();
 		$this->show_redis_cache_disabled_notice();
-		$this->show_object_cache_dropin_updated_notice();
 	}
 
 	/**
@@ -90,35 +89,5 @@ class AdminNotices {
 		$msg   = __( 'The Redis Object Cache plugin has been deactivated and can be removed. The SpinupWP plugin now handles clearing the Redis object cache.', 'spinupwp' );
 		$nonce = wp_create_nonce( 'dismiss-notice' );
 		echo "<div class=\"spinupwp notice notice-success is-dismissible\" data-nonce=\"{$nonce}\" data-notice=\"redis_cache_disabled\"><p><strong>SpinupWP</strong> — {$msg}</p></div>";
-	}
-
-	/**
-	 * Show a notice when the object-cache.php drop-in has been updated.
-	 */
-	public function show_object_cache_dropin_updated_notice() {
-		$wpcontent_dir = untrailingslashit( WP_CONTENT_DIR );
-
-		if ( file_exists( $wpcontent_dir . '/object-cache.php' ) ) {
-			$plugin_path = untrailingslashit( dirname( __DIR__ ) );
-
-			$dropin = get_plugin_data( $wpcontent_dir . '/object-cache.php' );
-			$plugin = get_plugin_data( $plugin_path . '/drop-ins/object-cache.php' );
-
-			if ( $dropin['PluginURI'] !== $plugin['PluginURI'] ) {
-				return;
-			}
-
-			if ( version_compare( $dropin['Version'], $plugin['Version'], '<' ) ) {
-				@unlink( $wpcontent_dir . '/object-cache.php' );
-
-				if ( @copy( $plugin_path . '/drop-ins/object-cache.php', $wpcontent_dir . '/object-cache.php' ) ) {
-					$msg = __( 'Object cache drop-in updated.', 'spinupwp' );
-					echo "<div class=\"spinupwp notice notice-success\"><p><strong>SpinupWP</strong> — {$msg}</p></div>";
-				} else {
-					$msg = __( 'Object cache drop-in could not be updated.', 'spinupwp' );
-					echo "<div class=\"spinupwp notice notice-error\"><p><strong>SpinupWP</strong> — {$msg}</p></div>";
-				}
-			}
-		}
 	}
 }

--- a/src/Cli/Commands.php
+++ b/src/Cli/Commands.php
@@ -13,36 +13,6 @@ use WP_CLI;
  *     $ wp spinupwp status
  */
 class Commands {
-
-	/**
-	 * Update the Redis object cache drop-in.
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     wp spinupwp update-object-cache-dropin
-	 *
-	 * @subcommand update-object-cache-dropin
-	 */
-	public function update_object_cache_dropin() {
-		$wpcontent_dir = untrailingslashit( WP_CONTENT_DIR );
-
-		if ( file_exists( $wpcontent_dir . '/object-cache.php' ) ) {
-			@unlink( $wpcontent_dir . '/object-cache.php' );
-		}
-
-		$plugin_path = untrailingslashit( dirname( dirname( __DIR__ ) ) );
-
-		if ( @copy( $plugin_path . '/drop-ins/object-cache.php', $wpcontent_dir . '/object-cache.php' ) ) {
-			WP_CLI::success( __( 'Object cache drop-in updated.', 'spinupwp' ) );
-		} else {
-			WP_CLI::error( __( 'Object cache drop-in could not be updated.', 'spinupwp' ) );
-		}
-
-		if ( function_exists( 'wp_cache_flush' ) ) {
-			wp_cache_flush();
-		}
-	}
-
 	/**
 	 * Show the status of SpinupWP.
 	 *

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -100,8 +100,8 @@ class Plugin {
 	 * Perform actions on admin init.
 	 */
 	public function admin_init() {
-		if ( is_plugin_active( 'redis-cache/redis-cache.php' ) ) {
-			deactivate_plugins( 'redis-cache/redis-cache.php' );
+        $wpcontent_dir = untrailingslashit( WP_CONTENT_DIR );
+		if (! is_plugin_active( 'redis-cache/redis-cache.php' ) || file_exists( $wpcontent_dir . '/object-cache.php' )) {
 			update_site_option( 'spinupwp_redis_cache_disabled', true );
 		}
 	}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,12 +67,6 @@ class Plugin {
 			@copy( $plugin_path . '/mu-plugins/spinupwp-debug-log-path.php', $wpmu_dir . '/spinupwp-debug-log-path.php' );
 		}
 
-		if ( file_exists( $wpcontent_dir . '/object-cache.php' ) ) {
-			@unlink( $wpcontent_dir . '/object-cache.php' );
-		}
-
-		@copy( $plugin_path . '/drop-ins/object-cache.php', $wpcontent_dir . '/object-cache.php' );
-
 		if ( function_exists( 'wp_cache_flush' ) ) {
 			wp_cache_flush();
 		}


### PR DESCRIPTION
Removed object-cache.php drop-in in favor of default from Redis Object Cache plugin.

Related to https://github.com/deliciousbrains/spinupwp/pull/2574