### PR TITLE
Object-Cache Update

### DIFF
--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: SpinupWP Redis Object Cache Drop-In
 Plugin URI: http://wordpress.org/plugins/spinupwp/
 Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, HHVM, replication, clustering and WP-CLI.
-Version: 1.3
+Version: 1.4
 Author: Delicious Brains
 Author URI: https://deliciousbrains.com/
 License: GPLv3

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -152,23 +152,11 @@ function wp_cache_incr( $key, $offset = 1, $group = '' ) {
 function wp_cache_init() {
     global $wp_object_cache;
 
-    if ( ! defined( 'WP_REDIS_PREFIX' ) && getenv( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
-        define( 'WP_REDIS_PREFIX', getenv( 'SPINUPWP_CACHE_KEY_SALT' ) );
+    if ( ! defined( 'WP_REDIS_PREFIX' )) {
+        define( 'WP_REDIS_PREFIX', $this->get_cache_key_salt());
     }
 
-    if ( ! defined( 'WP_REDIS_SELECTIVE_FLUSH' ) && getenv( 'WP_REDIS_SELECTIVE_FLUSH' ) ) {
-        define( 'WP_REDIS_SELECTIVE_FLUSH', (bool) getenv( 'WP_REDIS_SELECTIVE_FLUSH' ) );
-    }
-
-    // Backwards compatibility: map `WP_CACHE_KEY_SALT` constant to `WP_REDIS_PREFIX`.
-    if ( defined( 'WP_CACHE_KEY_SALT' ) && ! defined( 'WP_REDIS_PREFIX' ) ) {
-        define( 'WP_REDIS_PREFIX', WP_CACHE_KEY_SALT );
-    }
-
-    // Set unique prefix for sites hosted on Cloudways
-    if ( ! defined( 'WP_REDIS_PREFIX' ) && isset( $_SERVER['cw_allowed_ip'] ) )  {
-        define( 'WP_REDIS_PREFIX', getenv( 'HTTP_X_APP_USER' ) );
-    }
+    define( 'WP_REDIS_SELECTIVE_FLUSH', true);
 
     if ( ! ( $wp_object_cache instanceof WP_Object_Cache ) ) {
         $fail_gracefully = ! defined( 'WP_REDIS_GRACEFUL' ) || WP_REDIS_GRACEFUL;
@@ -176,6 +164,26 @@ function wp_cache_init() {
         // We need to override this WordPress global in order to inject our cache.
         $wp_object_cache = new WP_Object_Cache( $fail_gracefully );
     }
+}
+
+/**
+ * Get the cache key salt.
+ *
+ * @return string|null
+ */
+private function get_cache_key_salt() {
+    if ( defined( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
+        return SPINUPWP_CACHE_KEY_SALT;
+    }
+    if ( getenv( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
+        return getenv( 'SPINUPWP_CACHE_KEY_SALT' );
+    }
+    if ( defined( 'WP_CACHE_KEY_SALT' ) ) {
+        // @deprecated
+        return WP_CACHE_KEY_SALT;
+    }
+
+    return null;
 }
 
 /**

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -152,8 +152,8 @@ function wp_cache_incr( $key, $offset = 1, $group = '' ) {
 function wp_cache_init() {
     global $wp_object_cache;
 
-    if ( ! defined( 'WP_REDIS_PREFIX' ) && getenv( 'WP_REDIS_PREFIX' ) ) {
-        define( 'WP_REDIS_PREFIX', getenv( 'WP_REDIS_PREFIX' ) );
+    if ( ! defined( 'WP_REDIS_PREFIX' ) && getenv( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
+        define( 'WP_REDIS_PREFIX', getenv( 'SPINUPWP_CACHE_KEY_SALT' ) );
     }
 
     if ( ! defined( 'WP_REDIS_SELECTIVE_FLUSH' ) && getenv( 'WP_REDIS_SELECTIVE_FLUSH' ) ) {
@@ -174,7 +174,6 @@ function wp_cache_init() {
         $fail_gracefully = ! defined( 'WP_REDIS_GRACEFUL' ) || WP_REDIS_GRACEFUL;
 
         // We need to override this WordPress global in order to inject our cache.
-        // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
         $wp_object_cache = new WP_Object_Cache( $fail_gracefully );
     }
 }
@@ -805,7 +804,6 @@ class WP_Object_Cache {
             $clients = $is_cluster ? WP_REDIS_CLUSTER : WP_REDIS_SERVERS;
 
             foreach ( $clients as $index => $connection_string ) {
-                // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
                 $url_components = parse_url( $connection_string );
 
                 parse_str( $url_components['query'], $add_params );
@@ -1985,7 +1983,6 @@ LUA;
 
         $bytes = array_map(
             function ( $keys ) {
-                // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
                 return strlen( serialize( $keys ) );
             },
             $this->cache
@@ -2219,7 +2216,6 @@ LUA;
 
         // Don't attempt to unserialize data that wasn't serialized going in.
         if ( $this->is_serialized( $original ) ) {
-            // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
             $value = @unserialize( $original );
 
             return is_object( $value ) ? clone $value : $value;
@@ -2248,12 +2244,10 @@ LUA;
         }
 
         if ( is_array( $data ) || is_object( $data ) ) {
-            // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
             return serialize( $data );
         }
 
         if ( $this->is_serialized( $data, false ) ) {
-            // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
             return serialize( $data );
         }
 

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -156,8 +156,6 @@ function wp_cache_init() {
         define( 'WP_REDIS_PREFIX', get_cache_key_salt());
     }
 
-    define( 'WP_REDIS_SELECTIVE_FLUSH', true);
-
     if ( ! ( $wp_object_cache instanceof WP_Object_Cache ) ) {
         $fail_gracefully = ! defined( 'WP_REDIS_GRACEFUL' ) || WP_REDIS_GRACEFUL;
 
@@ -1267,7 +1265,7 @@ class WP_Object_Cache {
 
         if ( $this->redis_status() ) {
             $salt = defined( 'WP_REDIS_PREFIX' ) ? trim( WP_REDIS_PREFIX ) : null;
-            $selective = defined( 'WP_REDIS_SELECTIVE_FLUSH' ) ? WP_REDIS_SELECTIVE_FLUSH : null;
+            $selective = true; // @deprecated WP_REDIS_SELECTIVE_FLUSH
 
             $start_time = microtime( true );
 

--- a/drop-ins/object-cache.php
+++ b/drop-ins/object-cache.php
@@ -153,7 +153,7 @@ function wp_cache_init() {
     global $wp_object_cache;
 
     if ( ! defined( 'WP_REDIS_PREFIX' )) {
-        define( 'WP_REDIS_PREFIX', $this->get_cache_key_salt());
+        define( 'WP_REDIS_PREFIX', get_cache_key_salt());
     }
 
     define( 'WP_REDIS_SELECTIVE_FLUSH', true);
@@ -171,7 +171,7 @@ function wp_cache_init() {
  *
  * @return string|null
  */
-private function get_cache_key_salt() {
+function get_cache_key_salt() {
     if ( defined( 'SPINUPWP_CACHE_KEY_SALT' ) ) {
         return SPINUPWP_CACHE_KEY_SALT;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: cache, caching, performance
 Requires at least: 4.7
 Tested up to: 5.9
 Requires PHP: 7.1
-Stable tag: 1.3
+Stable tag: 1.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Create a new team account, invite a member of your team, and allow them to spin 
 * Ensures debug.log files aren’t saved in a publicly-accessible location
 
 == Changelog ==
+
+= 1.4 (2022-02-02) =
+* PHP 8.1 compatibility fixes
 
 = 1.3 (2021-01-06) =
 * Added compatibility with Elementor Website Builder.

--- a/spinupwp.php
+++ b/spinupwp.php
@@ -4,7 +4,7 @@ Plugin Name:  SpinupWP
 Plugin URI:   https://spinupwp.com
 Description:  SpinupWP helper plugin.
 Author:       Delicious Brains
-Version:      1.3
+Version:      1.4
 Network:      True
 Text Domain:  spinupwp
 Requires PHP: 7.1


### PR DESCRIPTION
I've updated the drop-in based on the [Redis Cache version](https://raw.githubusercontent.com/rhubarbgroup/redis-cache/develop/includes/object-cache.php). I swapped out our variable in `wp_cache_init()`. I tested on one of my sites and everything _seems_ to work as it did before. The only thing I'm not sure about for this PR is the versioning/tagging - what should I update that to? 

It looks like we automatically compare versions and update the dropin in the `show_object_cache_dropin_updated_notice()` in `AdminNotices.php`.